### PR TITLE
Add pdf + qcdscale weight info and temporary fix for btag jec

### DIFF
--- a/boostedhiggs/hwwprocessor.py
+++ b/boostedhiggs/hwwprocessor.py
@@ -769,6 +769,7 @@ class HwwProcessor(processor.ProcessorABC):
                 + self._yearmod: {
                     "sumgenweight": sumgenweight,
                     "sumlheweight": sumlheweight,
+                    "sumpdfweight": sumpdfweight,
                     "cutflows": self.cutflows,
                 },
             }


### PR DESCRIPTION
- [x] Save PDFweigths and sum
- [x] Save LHEweights and sum
- [x] Get rid of old implementations of these
- [x] put a temporary bare except for the propagation of AK4 JECs into mjj: we hit those exceptions when there is no jet1 or jet2?