### PR TITLE
Simplify WJetsNLO processor

### DIFF
--- a/boostedhiggs/wjetsnloprocessor.py
+++ b/boostedhiggs/wjetsnloprocessor.py
@@ -208,8 +208,8 @@ class VjetsProcessor(processor.ProcessorABC):
             else:
                 genVars = {}
             # save gen jet mass (not msd)
-            genVars["fj_genjetmass"] = candidatefj.matched_gen.mass
-            genVars["fj_genjetpt"] = candidatefj.matched_gen.pt
+            # genVars["fj_genjetmass"] = candidatefj.matched_gen.mass
+            # genVars["fj_genjetpt"] = candidatefj.matched_gen.pt
             variables = {**variables, **genVars}
 
         # apply dummy selection
@@ -221,9 +221,9 @@ class VjetsProcessor(processor.ProcessorABC):
                 # add corrections for plotting
                 variables["weight_ewkcorr"] = ewk_corr
                 variables["weight_qcdcorr"] = qcd_corr
-                variables["weight_altqcdcorr"] = alt_qcd_corr["nominal"]
-                variables["weight_altqcdcorr_up"] = alt_qcd_corr["up"]
-                variables["weight_altqcdcorr_down"] = alt_qcd_corr["down"]
+                # variables["weight_altqcdcorr"] = alt_qcd_corr["nominal"]
+                # variables["weight_altqcdcorr_up"] = alt_qcd_corr["up"]
+                # variables["weight_altqcdcorr_down"] = alt_qcd_corr["down"]
 
                 # store the final weight per ch
                 variables[f"weight_{ch}"] = self.weights[ch].weight()

--- a/pfnano_splitting.yaml
+++ b/pfnano_splitting.yaml
@@ -98,17 +98,17 @@ v2_2:
     ST_tW_top_5f_inclusiveDecays: 5
     ST_s-channel_4f_hadronicDecays: 5
     ST_s-channel_4f_leptonDecays: 5
-    WJetsToLNu_0J: 5
-    WJetsToLNu_1J: 5
-    WJetsToLNu_2J: 5
-    WJetsToLNu_LHEFilterPtW-250To400: 5
-    WJetsToLNu_LHEFilterPtW-400To600: 5
-    WJetsToLNu_LHEFilterPtW-600ToInf: 5
-    WJetsToLNu_012JetsNLO_34JetsLO_EWNLOcorr: 5
-    WJetsToLNu_Pt-100To250_MatchEWPDG20: 5
-    WJetsToLNu_Pt-250To400_MatchEWPDG20: 5
-    WJetsToLNu_Pt-400To600_MatchEWPDG20: 5
-    WJetsToLNu_Pt-600ToInf_MatchEWPDG20: 5
+    WJetsToLNu_0J: 10
+    WJetsToLNu_1J: 10
+    WJetsToLNu_2J: 10
+    WJetsToLNu_LHEFilterPtW-250To400: 10
+    WJetsToLNu_LHEFilterPtW-400To600: 10
+    WJetsToLNu_LHEFilterPtW-600ToInf: 10
+    WJetsToLNu_012JetsNLO_34JetsLO_EWNLOcorr: 10
+    WJetsToLNu_Pt-100To250_MatchEWPDG20: 10
+    WJetsToLNu_Pt-250To400_MatchEWPDG20: 10
+    WJetsToLNu_Pt-400To600_MatchEWPDG20: 10
+    WJetsToLNu_Pt-600ToInf_MatchEWPDG20: 10
     WJetsToLNu_TuneCP5_13TeV-madgraphMLM: 5
     WJetsToLNu_HT-70To100: 10
     WJetsToLNu_HT-100To200: 10


### PR DESCRIPTION
Tested with:
```
 python run.py --year 2018 --processor vjetsnlo --pfnano v2_2 --no-inference --systematics --no-getLPweights --no-uselooselep --n 2 --starti 0 --sample WJetsToLNu_1J --config samples_inclusive.yaml --key vjetsnlo --channels mu
```
Let's run only one channel, one year (2018):
```
python condor/submit.py --year 2018 --tag 25Mar12WJets --config samples_inclusive.yaml --key vjetsnlo --pfnano v2_2 --channels mu --no-inference --processor vjetsnlo --systematics
```